### PR TITLE
feat: performance statistics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
         "can_unpack.h": "c",
         "can_publisher.h": "c",
         "telemetry_protocol.h": "c",
-        "stdint.h": "c"
+        "stdint.h": "c",
+        "tx_api.h": "c"
     },
     "cortex-debug.variableUseNaturalFormat": false
 }

--- a/src/SUFST/inc/can_unpack.h
+++ b/src/SUFST/inc/can_unpack.h
@@ -13,11 +13,11 @@ typedef struct {
   TX_MUTEX stats_mutex; /* Mutex definition */
   int32_t rx_can_count; /* Received can frames */
   int32_t rx_can_bps; /* Received bits per second */
-  int32_t rxbytes;
+  int32_t rx_bytes;
   int32_t tx_pdu_count; /* Transmitted pdu frames */
   int32_t tx_pdu_bps; /* Transmitted bits per second */
-  int32_t txbytes;
-} unpack_performance_t;
+  int32_t tx_bytes;
+} unpack_stats_t;
 
 typedef struct {
 
@@ -29,7 +29,7 @@ typedef struct {
 
   rtcan_handle_t rtcan;
 
-  unpack_performance_t stats;
+  unpack_stats_t stats;
 
 } unpack_context_t;
 

--- a/src/SUFST/inc/can_unpack.h
+++ b/src/SUFST/inc/can_unpack.h
@@ -9,13 +9,14 @@
 
 typedef struct {
 
-  TX_TIMER bps_timer;
-  int32_t rx_can_count;
-  int32_t rx_can_bps;
-  int32_t rxbits;
-  int32_t tx_pdu_count;
-  int32_t tx_pdu_bps;
-  int32_t txbits;
+  TX_TIMER bps_timer; /* Timer definition */
+  TX_MUTEX stats_mutex; /* Mutex definition */
+  int32_t rx_can_count; /* Received can frames */
+  int32_t rx_can_bps; /* Received bits per second */
+  int32_t rxbytes;
+  int32_t tx_pdu_count; /* Transmitted pdu frames */
+  int32_t tx_pdu_bps; /* Transmitted bits per second */
+  int32_t txbytes;
 } unpack_performance_t;
 
 typedef struct {

--- a/src/SUFST/inc/can_unpack.h
+++ b/src/SUFST/inc/can_unpack.h
@@ -16,7 +16,7 @@ typedef struct {
   int32_t tx_pdu_count;
   int32_t tx_pdu_bps;
   int32_t txbits;
-} unpack_performace_t;
+} unpack_performance_t;
 
 typedef struct {
 
@@ -28,7 +28,7 @@ typedef struct {
 
   rtcan_handle_t rtcan;
 
-  unpack_performace_t stats;
+  unpack_performance_t stats;
 
 } unpack_context_t;
 

--- a/src/SUFST/inc/can_unpack.h
+++ b/src/SUFST/inc/can_unpack.h
@@ -3,8 +3,20 @@
 #include "tx_api.h"
 #include "telemetry_protocol.h"
 #include "rtcan.h"
+#include <stdint.h>
 
 #define CAN_PUBLISHER_RX_QUEUE_SIZE 10 //TODO: add config.h storing such values to avoid redefinition.
+
+typedef struct {
+
+  TX_TIMER bps_timer;
+  int32_t rx_can_count;
+  int32_t rx_can_bps;
+  int32_t rxbits;
+  int32_t tx_pdu_count;
+  int32_t tx_pdu_bps;
+  int32_t txbits;
+} unpack_performace_t;
 
 typedef struct {
 
@@ -16,9 +28,10 @@ typedef struct {
 
   rtcan_handle_t rtcan;
 
+  unpack_performace_t stats;
+
 } unpack_context_t;
 
 UINT unpack_init(unpack_context_t* unpack_ptr, TX_BYTE_POOL* stack_pool_ptr);
-
 
 #endif /* CAN_UNPACK_H */

--- a/src/SUFST/src/can_unpack.c
+++ b/src/SUFST/src/can_unpack.c
@@ -174,8 +174,8 @@ void queue_receive_thread_entry(ULONG input)
           return;
         }
         /* For statistic */
-        unpack_ptr->stats.tx_pdu_count;
-        unpack_ptr->stats.txbits += (sizeof(pdu_struct) * 8);       
+        unpack_ptr->stats.tx_pdu_count++;
+        unpack_ptr->stats.txbits += (sizeof(pdu_struct) * 8);     
     }
 }
 

--- a/src/SUFST/src/can_unpack.c
+++ b/src/SUFST/src/can_unpack.c
@@ -14,8 +14,8 @@
 #define STATS_TIMER_SECONDS                 STATS_TIMER_TICKS/100
 
 void queue_receive_thread_entry(ULONG input);
-void stats_init(unpack_performace_t* stats);
-void timer_callback(unpack_performace_t* stats);
+void stats_init(unpack_performance_t* stats);
+void timer_callback(unpack_performance_t* stats);
 
 UINT unpack_init(unpack_context_t* unpack_ptr, TX_BYTE_POOL* stack_pool_ptr){
 
@@ -179,7 +179,7 @@ void queue_receive_thread_entry(ULONG input)
     }
 }
 
-void stats_init(unpack_performace_t* stats)
+void stats_init(unpack_performance_t* stats)
 {
     stats->rx_can_bps = 0;
     stats->rx_can_count = 0;
@@ -189,7 +189,7 @@ void stats_init(unpack_performace_t* stats)
     stats->txbits = 0;
 }
 
-void timer_callback(unpack_performace_t* stats)
+void timer_callback(unpack_performance_t* stats)
 {
     stats->rx_can_bps = stats->rxbits / STATS_TIMER_SECONDS; /* Amount of bits received per second */
     stats->tx_pdu_bps = stats->txbits / STATS_TIMER_SECONDS; /* Amount of bits sent per second */

--- a/src/SUFST/src/can_unpack.c
+++ b/src/SUFST/src/can_unpack.c
@@ -12,10 +12,11 @@
 #define QUEUE_RX_THREAD_PREEMPTION_THRESHOLD 10
 #define STATS_TIMER_SECONDS                  1
 #define STATS_TIMER_TICKS                    STATS_TIMER_SECONDS * TX_TIMER_TICKS_PER_SECOND
+const uint32_t BITS_PER_BYTE = 8;
 
 static void queue_receive_thread_entry(ULONG input);
-static void stats_init(unpack_performance_t* stats);
-static void stats_timer_callback(unpack_performance_t* stats);
+static void stats_init(unpack_stats_t* stats);
+static void stats_timer_callback(unpack_stats_t* stats);
 
 UINT unpack_init(unpack_context_t* unpack_ptr, TX_BYTE_POOL* stack_pool_ptr){
 
@@ -77,7 +78,6 @@ rtcan_status_t can_status;
               TX_INHERIT);
     }
 
-
     /* Subscribe to can messages*/
     if (tx_status == TX_SUCCESS)
     {
@@ -128,7 +128,7 @@ void queue_receive_thread_entry(ULONG input)
         /* For statistic */
         tx_mutex_get(&unpack_ptr->stats.stats_mutex,TX_WAIT_FOREVER);
         unpack_ptr->stats.rx_can_count++;
-        unpack_ptr->stats.rxbytes += rx_msg_ptr->length;
+        unpack_ptr->stats.rx_bytes += rx_msg_ptr->length;
         tx_mutex_put(&unpack_ptr->stats.stats_mutex);
         /* Find the can handler of matching identifier */
         int id = 0;
@@ -186,27 +186,29 @@ void queue_receive_thread_entry(ULONG input)
         /* For statistic */
         tx_mutex_get(&unpack_ptr->stats.stats_mutex,TX_WAIT_FOREVER);
         unpack_ptr->stats.tx_pdu_count++;
-        unpack_ptr->stats.txbytes += sizeof(pdu_struct);
+        unpack_ptr->stats.tx_bytes += sizeof(pdu_struct);
         tx_mutex_put(&unpack_ptr->stats.stats_mutex);    
     }
 }
 
-void stats_init(unpack_performance_t* stats)
+void stats_init(unpack_stats_t* stats)
 {
     stats->rx_can_bps = 0;
     stats->rx_can_count = 0;
     stats->tx_pdu_bps = 0;
     stats->tx_pdu_count = 0;
-    stats->rxbytes = 0;
-    stats->txbytes = 0;
+    stats->rx_bytes = 0;
+    stats->tx_bytes = 0;
 }
 
-void stats_timer_callback(unpack_performance_t* stats)
+void stats_timer_callback(unpack_stats_t* stats)
 {
-    stats->rx_can_bps = stats->rxbytes * 8 / STATS_TIMER_SECONDS; /* Amount of bits received per second */
-    stats->tx_pdu_bps = stats->txbytes * 8 / STATS_TIMER_SECONDS; /* Amount of bits sent per second */
+    tx_mutex_get(&stats->stats_mutex,TX_WAIT_FOREVER);
+    stats->rx_can_bps = (stats->rx_bytes * BITS_PER_BYTE) / STATS_TIMER_SECONDS; /* Amount of bits received per second */
+    stats->tx_pdu_bps = (stats->tx_bytes * BITS_PER_BYTE) / STATS_TIMER_SECONDS; /* Amount of bits sent per second */
 
     /* Set counter to zeroes */
-    stats->rxbytes = 0;
-    stats->txbytes = 0;
+    stats->rx_bytes = 0;
+    stats->tx_bytes = 0;
+    tx_mutex_put(&stats->stats_mutex);
 }


### PR DESCRIPTION
### Changes
- Add basic performance profiling
- Performance data is stored in structure `unpack_performance_t` in `unpack_context_t`
- Bitrate per second is calculated periodically using ThreadX Software Timer
- Measurements include message headers.

### Related Issue(s)
Closes #10 